### PR TITLE
Add Scalar API reference endpoint and HTML

### DIFF
--- a/internal/swagger/endpoints.go
+++ b/internal/swagger/endpoints.go
@@ -36,6 +36,11 @@ func RegisterEndpoints(se *core.ServeEvent, generator *Generator) {
 		return e.HTML(http.StatusOK, html)
 	})
 
+	se.Router.GET("/api-docs/scalar", func(e *core.RequestEvent) error {
+		html := GetScalarHTML()
+		return e.HTML(http.StatusOK, html)
+	})
+
 	// Collection stats endpoint
 	se.Router.GET("/api-docs/stats", func(e *core.RequestEvent) error {
 		stats, err := generator.GetCollectionStats()

--- a/internal/swagger/ui.go
+++ b/internal/swagger/ui.go
@@ -58,3 +58,31 @@ func GetRedocHTML() string {
 </body>
 </html>`
 }
+
+func GetScalarHTML() string {
+	return `<!doctype html>
+<html>
+  <head>
+    <title>IMS PocketBase API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+
+  <body>
+    <div id="app"></div>
+
+    <!-- Load the Script -->
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+
+    <!-- Initialize the Scalar API Reference -->
+    <script>
+      Scalar.createApiReference('#app', {
+        // The URL of the OpenAPI/Swagger document
+        url: '/api-docs/openapi.json',
+      })
+    </script>
+  </body>
+</html>`
+}


### PR DESCRIPTION
Introduces a new /api-docs/scalar endpoint serving a Scalar-based API reference UI. Adds GetScalarHTML function to provide the required HTML for embedding Scalar, allowing users to view the OpenAPI documentation with an alternative interface.